### PR TITLE
Enhancements for Dataset Handling, Training Splits, Checkpoint Management, and Model Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ python finetune/finetune.py \
   --model_path="bigcode/starcoder"\
   --dataset_name="ArmelR/stack-exchange-instruction"\
   --subset="data/finetune"\
-  --split="train"\
+  --train_split="train" \
+  --valid_split="val" \
   --size_valid_set 10000\
   --streaming\
   --seq_length 2048\
@@ -154,29 +155,32 @@ python finetune/finetune.py \
   --num_warmup_steps 100\
   --weight_decay 0.05\
   --output_dir="./checkpoints" \
+  --save_limit 20 
 ```
 The size of the SE dataset is better manageable when using streaming. We also have to precise the split of the dataset that is used. For more details, check the [dataset's page](https://huggingface.co/datasets/ArmelR/stack-exchange-instruction) on 🤗. Similarly we can modify the command to account for the availability of GPUs
 
 ```bash
-python -m torch.distributed.launch \
-  --nproc_per_node number_of_gpus finetune/finetune.py \
-  --model_path="bigcode/starcoder"\
-  --dataset_name="ArmelR/stack-exchange-instruction"\
-  --subset="data/finetune"\
-  --split="train"\
-  --size_valid_set 10000\
+torchrun --nproc_per_node=number_of_gpus \
+   finetune/finetune.py \
+  --model_path="bigcode/starcoder" \
+  --dataset_name="ArmelR/stack-exchange-instruction" \
+  --subset="data/finetune" \
+  --train_split="train" \
+  --valid_split="val" \
+  --size_valid_set 10000 \
   --streaming \
-  --seq_length 2048\
-  --max_steps 1000\
-  --batch_size 1\
-  --input_column_name="question"\
-  --output_column_name="response"\ 
-  --gradient_accumulation_steps 16\
-  --learning_rate 1e-4\
-  --lr_scheduler_type="cosine"\
-  --num_warmup_steps 100\
-  --weight_decay 0.05\
+  --seq_length 2048 \
+  --max_steps 1000 \
+  --batch_size 1 \
+  --input_column_name="question" \
+  --output_column_name="response" \ 
+  --gradient_accumulation_steps 16 \
+  --learning_rate 1e-4 \
+  --lr_scheduler_type="cosine" \
+  --num_warmup_steps 100 \
+  --weight_decay 0.05 \
   --output_dir="./checkpoints" \
+  --save_limit 20 
 ```
 ## Merging PEFT adapter layers
 If you train a model with PEFT, you'll need to merge the adapter layers with the base model if you want to run inference / evaluation. To do so, run:

--- a/finetune/finetune.py
+++ b/finetune/finetune.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-import time
 
 import torch
 from accelerate import Accelerator
@@ -89,6 +88,7 @@ def get_args():
     parser.add_argument("--log_freq", default=100, type=int)
     parser.add_argument("--eval_freq", default=100, type=int)
     parser.add_argument("--save_freq", default=1000, type=int)
+    parser.add_argument("--save_limit", default=1000, type=int)
 
     return parser.parse_args()
 
@@ -295,6 +295,9 @@ def run_training(args, train_data, val_data):
         evaluation_strategy="steps",
         max_steps=args.max_steps,
         eval_steps=args.eval_freq,
+        save_strategy="steps",
+        save_total_limit=args.save_limit,
+        hub_strategy="all_checkpoints",
         save_steps=args.save_freq,
         logging_steps=args.log_freq,
         per_device_train_batch_size=args.batch_size,

--- a/finetune/finetune.py
+++ b/finetune/finetune.py
@@ -261,75 +261,81 @@ def create_datasets(tokenizer, args):
 
 
 def run_training(args, train_data, val_data):
-    print("Loading the model")
-    # disable caching mechanism when using gradient checkpointing
-    model = AutoModelForCausalLM.from_pretrained(
-        args.model_path,
-        use_auth_token=True,
-        use_cache=not args.no_gradient_checkpointing,
-        load_in_8bit=True,
-        device_map={"": Accelerator().process_index},
-    )
-    model = prepare_model_for_int8_training(model)
+    if dist.get_rank() == 0:
+        print("Loading the model")
+        
+        # disable caching mechanism when using gradient checkpointing
+        model = AutoModelForCausalLM.from_pretrained(
+            args.model_path,
+            use_auth_token=True,
+            use_cache=not args.no_gradient_checkpointing,
+            load_in_8bit=True,
+            device_map={"": Accelerator().process_index},
+        )
+        model = prepare_model_for_int8_training(model)
 
-    lora_config = LoraConfig(
-        r=args.lora_r,
-        lora_alpha=args.lora_alpha,
-        lora_dropout=args.lora_dropout,
-        bias="none",
-        task_type="CAUSAL_LM",
-        target_modules = ["c_proj", "c_attn", "q_attn"]
-    )
+        lora_config = LoraConfig(
+            r=args.lora_r,
+            lora_alpha=args.lora_alpha,
+            lora_dropout=args.lora_dropout,
+            bias="none",
+            task_type="CAUSAL_LM",
+            target_modules = ["c_proj", "c_attn", "q_attn"]
+        )
 
-    model = get_peft_model(model, lora_config)
+        model = get_peft_model(model, lora_config)
 
-    print_trainable_parameters(model)
+        print_trainable_parameters(model)
 
-    train_data.start_iteration = 0
+        train_data.start_iteration = 0
+    
+        print("Starting main loop")
 
-    print("Starting main loop")
-
-    training_args = TrainingArguments(
-        output_dir=args.output_dir,
-        optim="adamw_torch",
-        dataloader_drop_last=True,
-        evaluation_strategy="steps",
-        max_steps=args.max_steps,
-        eval_steps=args.eval_freq,
-        save_strategy="steps",
-        save_total_limit=args.save_limit,
-        hub_strategy="all_checkpoints",
-        save_steps=args.save_freq,
-        logging_steps=args.log_freq,
-        per_device_train_batch_size=args.batch_size,
-        per_device_eval_batch_size=args.batch_size,
-        learning_rate=args.learning_rate,
-        lr_scheduler_type=args.lr_scheduler_type,
-        warmup_steps=args.num_warmup_steps,
-        gradient_accumulation_steps=args.gradient_accumulation_steps,
-        gradient_checkpointing=not args.no_gradient_checkpointing,
-        fp16=not args.no_fp16,
-        bf16=args.bf16,
-        weight_decay=args.weight_decay,
-        run_name="StarCoder-finetuned",
-        report_to="wandb",
-        ddp_find_unused_parameters=False,
-        load_best_model_at_end=True,
-    )
-
+        training_args = TrainingArguments(
+            output_dir=args.output_dir,
+            optim="adamw_torch",
+            dataloader_drop_last=True,
+            evaluation_strategy="steps",
+            max_steps=args.max_steps,
+            eval_steps=args.eval_freq,
+            save_strategy="steps",
+            save_total_limit=args.save_limit,
+            hub_strategy="all_checkpoints",
+            save_steps=args.save_freq,
+            logging_steps=args.log_freq,
+            per_device_train_batch_size=args.batch_size,
+            per_device_eval_batch_size=args.batch_size,
+            learning_rate=args.learning_rate,
+            lr_scheduler_type=args.lr_scheduler_type,
+            warmup_steps=args.num_warmup_steps,
+            gradient_accumulation_steps=args.gradient_accumulation_steps,
+            gradient_checkpointing=not args.no_gradient_checkpointing,
+            fp16=not args.no_fp16,
+            bf16=args.bf16,
+            weight_decay=args.weight_decay,
+            run_name="StarCoder-finetuned",
+            report_to="wandb",
+            ddp_find_unused_parameters=False,
+            load_best_model_at_end=True,
+        )
+        print("Training...")
+        
+    for param in model.parameters():
+        dist.broadcast(param.data, src=0)
+        
     trainer = Trainer(model=model, args=training_args, train_dataset=train_data, eval_dataset=val_data, callbacks=[SavePeftModelCallback, LoadBestPeftModelCallback])
-
-    print("Training...")
     trainer.train()
     
-    final_checkpoint_path = os.path.join(args.output_dir, "final_checkpoint/")
-    model.save_pretrained(final_checkpoint_path)
-
-    print("Pushing the model to the hub")
-    model.push_to_hub(final_checkpoint_path)
+    if dist.get_rank() == 0:
+        print("Saving last checkpoint of the model")
+        final_checkpoint_path = os.path.join(args.output_dir, "final_checkpoint/")
+        model.save_pretrained(final_checkpoint_path)
+        print("Pushing the model to the hub")
+        model.push_to_hub(final_checkpoint_path)
 
 
 def main(args):
+    dist.init_process_group(backend='nccl')
     tokenizer = AutoTokenizer.from_pretrained(args.model_path, use_auth_token=True)
     train_dataset, eval_dataset = create_datasets(tokenizer, args)
     run_training(args, train_dataset, eval_dataset)

--- a/finetune/finetune.py
+++ b/finetune/finetune.py
@@ -125,7 +125,10 @@ def print_trainable_parameters(model):
 
 def prepare_sample_text(example, input_column_name="prompt", output_column_name="completion"):
     """Prepare the text from a sample of the dataset."""
-    text = f"Question: {example[input_column_name]}\n\nAnswer: {example[output_column_name]}"
+    if isinstance(example, dict):
+        text = f"Question: {example[input_column_name]}\n\nAnswer: {example[output_column_name]}"
+    else:
+        text = example
     return text
 
 

--- a/finetune/finetune.py
+++ b/finetune/finetune.py
@@ -78,7 +78,6 @@ def get_args():
     parser.add_argument("--num_warmup_steps", type=int, default=100)
     parser.add_argument("--weight_decay", type=float, default=0.05)
 
-    parser.add_argument("--local_rank", type=int, default=0)
     parser.add_argument("--no_fp16", action="store_false")
     parser.add_argument("--bf16", action="store_true", default=True)
     parser.add_argument("--no_gradient_checkpointing", action="store_false", default=False)
@@ -91,6 +90,8 @@ def get_args():
 
     return parser.parse_args()
 
+# Get the local rank from the environment variable for torchrun
+local_rank = int(os.getenv('LOCAL_RANK', '0'))
 
 def chars_token_ratio(dataset, tokenizer, input_column_name="prompt", output_column_name="completion", nb_examples=400):
     """

--- a/finetune/finetune.py
+++ b/finetune/finetune.py
@@ -291,6 +291,7 @@ def run_training(args, train_data, val_data):
 
     training_args = TrainingArguments(
         output_dir=args.output_dir,
+        optim="adamw_torch",
         dataloader_drop_last=True,
         evaluation_strategy="steps",
         max_steps=args.max_steps,
@@ -320,14 +321,12 @@ def run_training(args, train_data, val_data):
 
     print("Training...")
     trainer.train()
-
-    print("Saving last checkpoint of the model")
-    final_checkpoint = os.path.join(args.output_dir, "final_checkpoint")
+    
     final_checkpoint_path = os.path.join(args.output_dir, "final_checkpoint/")
     model.save_pretrained(final_checkpoint_path)
 
     print("Pushing the model to the hub")
-    model.push_to_hub(final_checkpoint)
+    model.push_to_hub(final_checkpoint_path)
 
 
 def main(args):

--- a/finetune/finetune.py
+++ b/finetune/finetune.py
@@ -322,11 +322,12 @@ def run_training(args, train_data, val_data):
     trainer.train()
 
     print("Saving last checkpoint of the model")
+    final_checkpoint = os.path.join(args.output_dir, "final_checkpoint")
     final_checkpoint_path = os.path.join(args.output_dir, "final_checkpoint/")
     model.save_pretrained(final_checkpoint_path)
 
     print("Pushing the model to the hub")
-    model.push_to_hub(final_checkpoint_path)
+    model.push_to_hub(final_checkpoint)
 
 
 def main(args):

--- a/finetune/finetune.py
+++ b/finetune/finetune.py
@@ -266,7 +266,7 @@ def run_training(args, train_data, val_data):
         print("Loading the model")
 
     model = AutoModelForCausalLM.from_pretrained(
-        args.model_path,
+        pretrained_model_name_or_path=args.model_path,
         use_auth_token=True,
         use_cache=not args.no_gradient_checkpointing,
         load_in_8bit=True,
@@ -325,12 +325,11 @@ def run_training(args, train_data, val_data):
     trainer = Trainer(model=model, args=training_args, train_dataset=train_data, eval_dataset=val_data, callbacks=[SavePeftModelCallback, LoadBestPeftModelCallback])
     trainer.train()
     
-    if dist.get_rank() == 0:
-        print("Saving last checkpoint of the model")
-        final_checkpoint_path = os.path.join(args.output_dir, "final_checkpoint/")
-        model.save_pretrained(final_checkpoint_path)
-        print("Pushing the model to the hub")
-        model.push_to_hub(final_checkpoint_path)
+    print("Saving last checkpoint of the model")
+    final_checkpoint_path = os.path.join(args.output_dir, "final_cp/")
+    model.save_pretrained(final_checkpoint_path)
+    print("Pushing the model to the hub")
+    model.push_to_hub(final_checkpoint_path)
 
 
 def main(args):


### PR DESCRIPTION
- Import Dataset and get_dataset_split_names from datasets to enable more flexible data handling
- Add --train_split and --valid_split arguments in get_args() function for user-defined train and validation splits
- Add --save_limit argument in get_args() function to control the number of model checkpoints saved
- Add local_rank to get the local rank from the environment variable for torchrun, enabling distributed training
- Update prepare_sample_text() function to check if the example is a dictionary, enhancing data compatibility
- Update create_datasets() function to handle train and validation split based on --train_split and --valid_split arguments, providing more flexibility in dataset splitting
- Update run_training() function to include save_strategy, save_total_limit, hub_strategy, and load_best_model_at_end in TrainingArguments, providing more control over model saving and loading
- Add step in run_training() function to push the model to the hub after saving the final checkpoint, facilitating model sharing
- Add print statement to indicate when the model is being pushed to the hub, improving user feedback
