### PR TITLE
add 'dataset_config_name' field to config.py with metadata

### DIFF
--- a/chat/config.py
+++ b/chat/config.py
@@ -65,6 +65,9 @@ class DataArguments:
     dataset_name: Optional[str] = field(
         default=None, metadata={"help": "The name of the dataset to use (via the datasets library)."}
     )
+    dataset_config_name: Optional[str] = field(
+        default=None, metadata={"help": "The configuration name of the dataset to use (via the datasets library)."}
+    )
     max_train_samples: Optional[int] = field(
         default=None,
         metadata={


### PR DESCRIPTION
#32 #59 
I had same error right after training finished. So I investigated about this.
Searching by keyword, I found code examples that I think the author may have referenced in writing the initial code from huggingface transformers examples.
https://github.com/huggingface/transformers/blob/main/examples/pytorch/language-modeling/run_plm.py

The authors of transformer appear to be using this value to specify subset of dataset.
E.g., specifying sst2 which is a subset of the glue dataset (https://huggingface.co/docs/datasets/v1.11.0/loading_datasets.html#selecting-a-configuration)
This value later functions as the name parameter of datasets.load_dataset.
(https://huggingface.co/docs/datasets/v1.11.0/package_reference/loading_methods.html#datasets.load_dataset)

This setting was excluded from writing train.py in starcoder, but the logic to check which dataset and subset was used at the time of saving the model was not excluded.
So it appears that the issue is caused by trying to reference a setting that doesn't exist.

A solution might be to remove the logic that checks the subset name.
However, since I guess that this code may also use a dataset with a subset, I think the setting value should be added to config.py and config field should be made to set the value in train.py. It is an optional parameter that will be None if not set by the user.

How about add 'dataset_config_name' field to config.py with metadata of transformer?
