### PR TITLE
fix mask_user_labels

### DIFF
--- a/chat/dialogues.py
+++ b/chat/dialogues.py
@@ -112,17 +112,17 @@ class DialogueTemplate(ModelHubMixin):
 
     @classmethod
     def _from_pretrained(
-        cls: Type[T],
-        *,
-        model_id: str,
-        revision: Optional[str],
-        cache_dir: Optional[Union[str, Path]],
-        force_download: bool,
-        proxies: Optional[Dict],
-        resume_download: bool,
-        local_files_only: bool,
-        token: Optional[Union[str, bool]],
-        **model_kwargs,
+            cls: Type[T],
+            *,
+            model_id: str,
+            revision: Optional[str],
+            cache_dir: Optional[Union[str, Path]],
+            force_download: bool,
+            proxies: Optional[Dict],
+            resume_download: bool,
+            local_files_only: bool,
+            token: Optional[Union[str, bool]],
+            **model_kwargs,
     ) -> T:
         """Loads the dialogue template from a local directory or the Huggingface Hub.
 
@@ -232,10 +232,11 @@ def prepare_dialogue(example, dialogue_template, is_train=True):
 def mask_user_labels(tokenizer, dialogue_template, labels):
     """Masks the user turns of a dialogue from the loss"""
     user_token_id = tokenizer.convert_tokens_to_ids(dialogue_template.user_token)
+    system_token_id = tokenizer.convert_tokens_to_ids(dialogue_template.system_token)
     assistant_token_id = tokenizer.convert_tokens_to_ids(dialogue_template.assistant_token)
     for idx, label_id in enumerate(labels):
-        if label_id == user_token_id:
+        if label_id in [user_token_id, system_token_id]:
             current_idx = idx
-            while labels[current_idx] != assistant_token_id and current_idx < len(labels):
+            while current_idx < len(labels) and labels[current_idx] != assistant_token_id:
                 labels[current_idx] = IGNORE_INDEX
                 current_idx += 1

--- a/chat/train.py
+++ b/chat/train.py
@@ -201,7 +201,8 @@ def main():
             for k, t in concatenated_examples.items()
         }
         labels = result["input_ids"].copy()
-        mask_user_labels(tokenizer, dialogue_template, labels)
+        for label in labels:
+            mask_user_labels(tokenizer, dialogue_template, label)
         result["labels"] = labels
         return result
 


### PR DESCRIPTION
Dear authors of Starcoder, while using the framework, I noticed that mask_user_labels sometimes does not function properly. Upon investigation, I found that there might be an issue with the function invocation. Here are my modifications：

1. In the group_texts() function in train.py, the result["input_ids"] has a structure of lists nested within lists. However, mask_user_labels deals with a single-layered list structure. Therefore, mask_user_labels did not function as expected. I used a loop to process each label separately, allowing the function to be called normally.
2. In the mask_user_labels function, I added masking for system-related labels. Moreover, the condition current_idx < len(labels) in the while loop should be placed at the beginning; otherwise, this condition becomes meaningless and can lead to out-of-bounds access with labels[current_idx].