### PR TITLE
Fix run finetune.py from torch.distributed.launch

### DIFF
--- a/finetune/finetune.py
+++ b/finetune/finetune.py
@@ -76,7 +76,7 @@ def get_args():
     parser.add_argument("--num_warmup_steps", type=int, default=100)
     parser.add_argument("--weight_decay", type=float, default=0.05)
 
-    parser.add_argument("--local_rank", type=int, default=0)
+    parser.add_argument("--local-rank", type=int, default=0)
     parser.add_argument("--no_fp16", action="store_false")
     parser.add_argument("--bf16", action="store_true", default=True)
     parser.add_argument("--no_gradient_checkpointing", action="store_false", default=False)


### PR DESCRIPTION
To fix the `unrecognized arguments` problem, when running finetune.py from `torch.distributed.launch`. 
the argument `local_rank` needs to be changed to `local-rank`.

launch command:
```shell
python -m torch.distributed.launch --nproc_per_node=2 finetune.py --model_path xxx ...
```
error log
```txt
finetune.py: error: unrecognized arguments: --local-rank=0
```

